### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project implements a Model Context Protocol (MCP) server to interact with Borrow Automated Market Maker (BAMM) contracts on the Fraxtal blockchain. It allows MCP-compatible clients (like AI assistants, IDE extensions, or custom applications) to manage BAMM positions, borrow against LP tokens, and perform other operations related to the BAMM protocol.
 
+<a href="https://glama.ai/mcp/servers/@IQAIcom/mcp-bamm">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@IQAIcom/mcp-bamm/badge" alt="MCP-BAMM MCP server" />
+</a>
+
 This server is built using TypeScript and `fastmcp`.
 
 ## Features (MCP Tools)


### PR DESCRIPTION
This PR adds a badge for the [MCP-BAMM](https://glama.ai/mcp/servers/@IQAIcom/mcp-bamm) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@IQAIcom/mcp-bamm">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@IQAIcom/mcp-bamm/badge" alt="MCP-BAMM MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.