### PR TITLE
chore: rename IQAICOM/IQAIcom to IQOfficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npx @iqai/mcp-bamm
 ### Build from Source
 
 ```bash
-git clone https://github.com/IQAIcom/mcp-bamm.git
+git clone https://github.com/IQOfficial/mcp-bamm.git
 cd mcp-bamm
 pnpm install
 pnpm run build

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
 	"author": "IQAI",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/IQAIcom/mcp-bamm.git"
+		"url": "https://github.com/IQOfficial/mcp-bamm.git"
 	},
 	"license": "ISC",
-	"homepage": "https://github.com/IQAIcom/mcp-bamm",
+	"homepage": "https://github.com/IQOfficial/mcp-bamm",
 	"bugs": {
-		"url": "https://github.com/IQAIcom/mcp-bamm/issues"
+		"url": "https://github.com/IQOfficial/mcp-bamm/issues"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Renames `IQAICOM`, `IQAIcom`, and `iqaicom` references to `IQOfficial` / `iqofficial` (case-preserving) as part of the brand handle rename. Covers Twitter/X handles, GitHub URLs, Telegram links, package metadata, badges, and docs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>